### PR TITLE
Add Paygate.clar: Subscription-Based Access Control Smart Contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/** linguist-vendored
+vitest.config.js linguist-vendored
+* text=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.cache/**
+history.txt
+
+logs
+*.log
+npm-debug.log*
+coverage
+*.info
+costs-reports.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+Overview
+This Clarity smart contract enables subscription-based access control using STX payments. Users can subscribe for a fixed period (default: 30 days) by paying a set price. The contract tracks subscriptions and allows an admin to manage pricing, revoke access, and withdraw funds.
+
+Features
+Subscribe: Users pay STX to gain access for 30 days.
+Check Access: Verify if a user’s subscription is active.
+Admin Controls:
+Update subscription price.
+Revoke user subscriptions.
+Withdraw collected STX.
+Usage
+subscribe: Users call this function to subscribe (requires payment).
+check-access: Read-only function to check if a user is currently subscribed.
+set-price: Admin can update the subscription price.
+revoke: Admin can revoke a user's subscription.
+withdraw: Admin can withdraw STX from the contract.

--- a/contracts/Paygate.clar
+++ b/contracts/Paygate.clar
@@ -1,0 +1,76 @@
+;; Subscription-Based Access Control Contract
+
+(define-constant admin 'SP000000000000000000002Q6VF78) ;; Replace with actual admin principal
+(define-constant subscription-duration u2592000) ;; 30 days in seconds
+(define-data-var subscription-price uint u1000000) ;; 1 STX in microSTX
+
+(define-map subscriptions 
+  { subscriber: principal }
+  { expires-at: uint }
+)
+
+;; Public: Subscribe for a time period
+(define-public (subscribe)
+  (let (
+        (price (var-get subscription-price))
+        ;; Clarity does not provide a direct block-height function, so we use a parameter instead
+        (current-height u0) ;; TODO: Pass the current block height as a parameter to this function
+      )
+    ;; Transfer STX to contract
+    (try! (stx-transfer? price tx-sender (as-contract tx-sender)))
+
+    ;; Get current subscription (if any)
+    (match (map-get? subscriptions { subscriber: tx-sender })
+      subscription
+      (map-set subscriptions { subscriber: tx-sender }
+        { expires-at:
+            (let (
+              (current-expiry (get expires-at subscription))
+            )
+              (if (> current-expiry current-height)
+                (+ current-expiry subscription-duration)
+                (+ current-height subscription-duration)
+              )
+            )
+        })
+      (map-set subscriptions { subscriber: tx-sender } { expires-at: (+ current-height subscription-duration) })
+    )
+    (ok true)
+  )
+)
+;; Read-only: Check if a user is currently subscribed
+(define-read-only (check-access (user principal) (current-height uint))
+  (match (map-get? subscriptions { subscriber: user })
+    subscription
+    (ok (> (get expires-at subscription) current-height))
+    (ok false)
+  )
+)
+
+
+;; Admin-only: Change subscription price
+(define-public (set-price (new-price uint))
+  (begin
+    (asserts! (is-eq tx-sender admin) (err u403)) ;; Unauthorized
+    (var-set subscription-price new-price)
+    (ok new-price)
+  )
+)
+
+;; Admin-only: Revoke a user's subscription
+(define-public (revoke (user principal))
+  (begin
+    (asserts! (is-eq tx-sender admin) (err u403))
+    (map-delete subscriptions { subscriber: user })
+    (ok true)
+  )
+)
+
+;; Admin-only: Withdraw STX from contract
+(define-public (withdraw (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender admin) (err u403))
+    (try! (stx-transfer? amount (as-contract tx-sender) admin))
+    (ok true)
+  )
+)


### PR DESCRIPTION
This PR introduces [Paygate.clar](vscode-file://vscode-app/c:/Users/USER/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), a Clarity smart contract for subscription-based access control on the Stacks blockchain. Key features include:

Users can subscribe for 30 days by paying a configurable price (default: 1 STX).
Admin can update the subscription price, revoke user subscriptions, and withdraw collected STX.
Subscription status is tracked per user, with expiration times managed in a map.
Includes a read-only function to check if a user’s subscription is active.